### PR TITLE
feat: Implement Rust benchmark parser (#2)

### DIFF
--- a/internal/parser/doc.go
+++ b/internal/parser/doc.go
@@ -1,0 +1,115 @@
+// Package parser provides benchmark output parsers for multiple languages.
+//
+// The parser package defines a common interface for parsing benchmark results
+// from different programming languages and testing frameworks. Each parser
+// implementation converts language-specific output into a unified BenchmarkSuite
+// format for aggregation and reporting.
+//
+// # Supported Formats
+//
+// Currently supported benchmark formats:
+//
+//   - Rust: cargo bench bencher format
+//
+// Planned support:
+//
+//   - Rust: criterion format
+//   - Python: pytest-benchmark JSON
+//   - Go: testing.B output
+//
+// # Usage
+//
+// Basic usage example:
+//
+//	parser := parser.NewRustParser()
+//	output := []byte(`test bench_sort ... bench:   1,234 ns/iter (+/- 56)`)
+//	suite, err := parser.Parse(output)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	for _, result := range suite.Results {
+//	    fmt.Printf("%s: %v ± %v\n", result.Name, result.Time, result.StdDev)
+//	}
+//
+// # Parser Interface
+//
+// All parsers implement the Parser interface:
+//
+//	type Parser interface {
+//	    Parse(output []byte) (*BenchmarkSuite, error)
+//	    Language() string
+//	}
+//
+// This allows for polymorphic handling of different benchmark formats:
+//
+//	var parser parser.Parser
+//	switch lang {
+//	case "rust":
+//	    parser = parser.NewRustParser()
+//	case "python":
+//	    parser = parser.NewPythonParser()
+//	default:
+//	    return fmt.Errorf("unsupported language: %s", lang)
+//	}
+//
+//	suite, err := parser.Parse(benchmarkOutput)
+//
+// # Data Structures
+//
+// BenchmarkResult represents a single benchmark with:
+//   - Name: benchmark identifier
+//   - Language: source language
+//   - Time: average execution time per iteration
+//   - Iterations: number of iterations run
+//   - StdDev: standard deviation of measurements
+//   - Throughput: optional throughput metrics (bytes/sec, ops/sec)
+//   - Metadata: additional key-value data
+//
+// BenchmarkSuite represents a collection of benchmark results with:
+//   - Results: slice of BenchmarkResult
+//   - Language: source language for all results
+//   - Timestamp: when benchmarks were parsed
+//   - Metadata: suite-level metadata
+//
+// # Error Handling
+//
+// Parsers return ParseError for recoverable parsing errors with context:
+//
+//	if err != nil {
+//	    if parseErr, ok := err.(*parser.ParseError); ok {
+//	        fmt.Printf("Parse error at line %d: %s\n", parseErr.Line, parseErr.Message)
+//	    }
+//	    return err
+//	}
+//
+// # Rust Parser Specifics
+//
+// The Rust parser supports cargo bench bencher format output:
+//
+// Expected format:
+//
+//	test bench_name ... bench:   1,234 ns/iter (+/- 56)
+//
+// Features:
+//   - Handles comma-separated numbers (1,234)
+//   - Extracts benchmark name, time, and standard deviation
+//   - Skips failed and ignored tests
+//   - Tolerates compiler warnings and other output
+//   - Parses zero nanosecond results
+//   - Handles large numbers (microseconds, milliseconds)
+//
+// Edge cases handled:
+//   - Zero variance: bench:   100 ns/iter (+/- 0)
+//   - Large numbers: bench:  12,345,678 ns/iter (+/- 987,654)
+//   - Failed tests: test bench_failed ... FAILED (skipped)
+//   - Ignored tests: test bench_ignored ... ignored (skipped)
+//
+// # Future Extensions
+//
+// Planned additions:
+//   - Criterion format parser with histogram data
+//   - Python pytest-benchmark JSON parser
+//   - Go testing.B output parser
+//   - Custom format support via configuration
+package parser

--- a/internal/parser/rust.go
+++ b/internal/parser/rust.go
@@ -1,0 +1,110 @@
+package parser
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RustParser implements Parser for Rust cargo bench output
+type RustParser struct{}
+
+// NewRustParser creates a new Rust benchmark parser
+func NewRustParser() *RustParser {
+	return &RustParser{}
+}
+
+// Language returns the language this parser supports
+func (p *RustParser) Language() string {
+	return "rust"
+}
+
+// Parse parses Rust cargo bench bencher format output
+// Expected format: test bench_name ... bench:   1,234 ns/iter (+/- 56)
+func (p *RustParser) Parse(output []byte) (*BenchmarkSuite, error) {
+	suite := &BenchmarkSuite{
+		Language:  "rust",
+		Timestamp: time.Now(),
+		Results:   make([]*BenchmarkResult, 0),
+		Metadata:  make(map[string]string),
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	lineNum := 0
+
+	// Regex for bencher format: test bench_name ... bench:   1,234 ns/iter (+/- 56)
+	benchRegex := regexp.MustCompile(`^test\s+(\S+)\s+\.\.\.\s+bench:\s+([\d,]+)\s+ns/iter\s+\(\+/-\s+([\d,]+)\)`)
+
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines and non-benchmark lines
+		if line == "" || !strings.Contains(line, "bench:") {
+			continue
+		}
+
+		// Match benchmark line
+		matches := benchRegex.FindStringSubmatch(line)
+		if matches == nil {
+			// Line contains "bench:" but doesn't match format - might be error
+			if strings.Contains(line, "FAILED") || strings.Contains(line, "ignored") {
+				continue // Skip failed/ignored tests
+			}
+			continue
+		}
+
+		// Extract benchmark name, time, and std dev
+		name := matches[1]
+		timeStr := strings.ReplaceAll(matches[2], ",", "")
+		stdDevStr := strings.ReplaceAll(matches[3], ",", "")
+
+		// Parse time in nanoseconds
+		timeNs, err := strconv.ParseInt(timeStr, 10, 64)
+		if err != nil {
+			return nil, &ParseError{
+				Line:    lineNum,
+				Message: fmt.Sprintf("failed to parse time: %v", err),
+				Input:   line,
+			}
+		}
+
+		// Parse std dev in nanoseconds
+		stdDevNs, err := strconv.ParseInt(stdDevStr, 10, 64)
+		if err != nil {
+			return nil, &ParseError{
+				Line:    lineNum,
+				Message: fmt.Sprintf("failed to parse std dev: %v", err),
+				Input:   line,
+			}
+		}
+
+		// Create benchmark result
+		result := &BenchmarkResult{
+			Name:       name,
+			Language:   "rust",
+			Time:       time.Duration(timeNs) * time.Nanosecond,
+			Iterations: 1, // Bencher doesn't report iterations, averaged internally
+			StdDev:     time.Duration(stdDevNs) * time.Nanosecond,
+			Metadata:   make(map[string]string),
+		}
+
+		suite.Results = append(suite.Results, result)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading input: %w", err)
+	}
+
+	if len(suite.Results) == 0 {
+		return nil, &ParseError{
+			Message: "no benchmark results found in output",
+		}
+	}
+
+	return suite, nil
+}

--- a/internal/parser/rust_test.go
+++ b/internal/parser/rust_test.go
@@ -1,0 +1,252 @@
+package parser
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestRustParser_Language(t *testing.T) {
+	parser := NewRustParser()
+	if got := parser.Language(); got != "rust" {
+		t.Errorf("Language() = %v, want %v", got, "rust")
+	}
+}
+
+func TestRustParser_Parse_BasicBencher(t *testing.T) {
+	input := []byte(`running 5 tests
+test bench_bubble_sort ... bench:   1,234 ns/iter (+/- 56)
+test bench_quick_sort  ... bench:     567 ns/iter (+/- 23)
+test bench_merge_sort  ... bench:     890 ns/iter (+/- 45)
+test bench_heap_sort   ... bench:   1,100 ns/iter (+/- 78)
+test bench_insertion   ... bench:   2,345 ns/iter (+/- 123)
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out`)
+
+	parser := NewRustParser()
+	suite, err := parser.Parse(input)
+
+	if err != nil {
+		t.Fatalf("Parse() error = %v, want nil", err)
+	}
+
+	if suite == nil {
+		t.Fatal("Parse() returned nil suite")
+	}
+
+	// Check suite metadata
+	if suite.Language != "rust" {
+		t.Errorf("Suite.Language = %v, want %v", suite.Language, "rust")
+	}
+
+	// Check number of results
+	if len(suite.Results) != 5 {
+		t.Fatalf("len(Results) = %d, want %d", len(suite.Results), 5)
+	}
+
+	// Verify first benchmark
+	first := suite.Results[0]
+	if first.Name != "bench_bubble_sort" {
+		t.Errorf("Results[0].Name = %v, want %v", first.Name, "bench_bubble_sort")
+	}
+	if first.Time != 1234*time.Nanosecond {
+		t.Errorf("Results[0].Time = %v, want %v", first.Time, 1234*time.Nanosecond)
+	}
+	if first.StdDev != 56*time.Nanosecond {
+		t.Errorf("Results[0].StdDev = %v, want %v", first.StdDev, 56*time.Nanosecond)
+	}
+	if first.Language != "rust" {
+		t.Errorf("Results[0].Language = %v, want %v", first.Language, "rust")
+	}
+
+	// Verify last benchmark
+	last := suite.Results[4]
+	if last.Name != "bench_insertion" {
+		t.Errorf("Results[4].Name = %v, want %v", last.Name, "bench_insertion")
+	}
+	if last.Time != 2345*time.Nanosecond {
+		t.Errorf("Results[4].Time = %v, want %v", last.Time, 2345*time.Nanosecond)
+	}
+}
+
+func TestRustParser_Parse_WithWarnings(t *testing.T) {
+	data, err := os.ReadFile("../../testdata/rust/cargo_bench_with_warnings.txt")
+	if err != nil {
+		t.Skipf("Skipping test - testdata file not found: %v", err)
+		return
+	}
+
+	parser := NewRustParser()
+	suite, err := parser.Parse(data)
+
+	if err != nil {
+		t.Fatalf("Parse() error = %v, want nil", err)
+	}
+
+	// Should parse benchmarks despite warnings
+	if len(suite.Results) != 3 {
+		t.Errorf("len(Results) = %d, want %d", len(suite.Results), 3)
+	}
+
+	// Verify specific benchmark
+	for _, result := range suite.Results {
+		if result.Name == "bench_fast_operation" {
+			if result.Time != 42*time.Nanosecond {
+				t.Errorf("bench_fast_operation Time = %v, want %v", result.Time, 42*time.Nanosecond)
+			}
+			if result.StdDev != 3*time.Nanosecond {
+				t.Errorf("bench_fast_operation StdDev = %v, want %v", result.StdDev, 3*time.Nanosecond)
+			}
+		}
+	}
+}
+
+func TestRustParser_Parse_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		wantResults    int
+		wantErr        bool
+		checkFirstName string
+		checkFirstTime time.Duration
+	}{
+		{
+			name: "zero nanoseconds",
+			input: `test bench_very_fast ... bench:       0 ns/iter (+/- 0)
+test result: ok.`,
+			wantResults:    1,
+			wantErr:        false,
+			checkFirstName: "bench_very_fast",
+			checkFirstTime: 0,
+		},
+		{
+			name: "large numbers",
+			input: `test bench_slow ... bench:  12,345,678 ns/iter (+/- 987,654)
+test result: ok.`,
+			wantResults:    1,
+			wantErr:        false,
+			checkFirstName: "bench_slow",
+			checkFirstTime: 12345678 * time.Nanosecond,
+		},
+		{
+			name: "single digit",
+			input: `test bench_fast ... bench:       5 ns/iter (+/- 1)
+test result: ok.`,
+			wantResults:    1,
+			wantErr:        false,
+			checkFirstName: "bench_fast",
+			checkFirstTime: 5 * time.Nanosecond,
+		},
+		{
+			name: "with underscores in name",
+			input: `test bench_with_many_underscores ... bench:     100 ns/iter (+/- 10)
+test result: ok.`,
+			wantResults:    1,
+			wantErr:        false,
+			checkFirstName: "bench_with_many_underscores",
+			checkFirstTime: 100 * time.Nanosecond,
+		},
+		{
+			name:        "empty input",
+			input:       "",
+			wantResults: 0,
+			wantErr:     true,
+		},
+		{
+			name: "no benchmarks found",
+			input: `running 0 tests
+test result: ok. 0 passed`,
+			wantResults: 0,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := NewRustParser()
+			suite, err := parser.Parse([]byte(tt.input))
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if len(suite.Results) != tt.wantResults {
+				t.Errorf("len(Results) = %d, want %d", len(suite.Results), tt.wantResults)
+			}
+
+			if tt.wantResults > 0 && tt.checkFirstName != "" {
+				if suite.Results[0].Name != tt.checkFirstName {
+					t.Errorf("Results[0].Name = %v, want %v", suite.Results[0].Name, tt.checkFirstName)
+				}
+				if suite.Results[0].Time != tt.checkFirstTime {
+					t.Errorf("Results[0].Time = %v, want %v", suite.Results[0].Time, tt.checkFirstTime)
+				}
+			}
+		})
+	}
+}
+
+func TestRustParser_Parse_FromFile(t *testing.T) {
+	data, err := os.ReadFile("../../testdata/rust/cargo_bench_bencher.txt")
+	if err != nil {
+		t.Skipf("Skipping test - testdata file not found: %v", err)
+		return
+	}
+
+	parser := NewRustParser()
+	suite, err := parser.Parse(data)
+
+	if err != nil {
+		t.Fatalf("Parse() error = %v, want nil", err)
+	}
+
+	if len(suite.Results) != 5 {
+		t.Errorf("len(Results) = %d, want %d", len(suite.Results), 5)
+	}
+}
+
+func TestRustParser_Parse_SkipsFailedTests(t *testing.T) {
+	input := []byte(`running 3 tests
+test bench_success ... bench:     100 ns/iter (+/- 10)
+test bench_failed ... FAILED
+test bench_another ... bench:     200 ns/iter (+/- 20)
+
+test result: FAILED. 2 passed; 1 failed`)
+
+	parser := NewRustParser()
+	suite, err := parser.Parse(input)
+
+	if err != nil {
+		t.Fatalf("Parse() error = %v, want nil", err)
+	}
+
+	// Should only parse successful benchmarks
+	if len(suite.Results) != 2 {
+		t.Errorf("len(Results) = %d, want %d (failed test should be skipped)", len(suite.Results), 2)
+	}
+}
+
+func TestRustParser_Parse_IgnoredTests(t *testing.T) {
+	input := []byte(`running 2 tests
+test bench_normal ... bench:     100 ns/iter (+/- 10)
+test bench_ignored ... ignored
+
+test result: ok. 1 passed; 0 failed; 1 ignored`)
+
+	parser := NewRustParser()
+	suite, err := parser.Parse(input)
+
+	if err != nil {
+		t.Fatalf("Parse() error = %v, want nil", err)
+	}
+
+	// Should only parse non-ignored benchmarks
+	if len(suite.Results) != 1 {
+		t.Errorf("len(Results) = %d, want %d (ignored test should be skipped)", len(suite.Results), 1)
+	}
+}

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -1,0 +1,51 @@
+package parser
+
+import "time"
+
+// BenchmarkResult represents a single benchmark result
+type BenchmarkResult struct {
+	Name       string            // Benchmark name (e.g., "bench_sort")
+	Language   string            // Language (e.g., "rust", "python", "go")
+	Time       time.Duration     // Average time per iteration
+	Iterations int64             // Number of iterations
+	StdDev     time.Duration     // Standard deviation
+	Throughput *Throughput       // Optional throughput metrics
+	Metadata   map[string]string // Additional metadata
+}
+
+// Throughput represents throughput metrics (bytes/sec, ops/sec, etc.)
+type Throughput struct {
+	Value float64
+	Unit  string // "MB/s", "ops/s", etc.
+}
+
+// BenchmarkSuite represents a collection of benchmark results
+type BenchmarkSuite struct {
+	Results   []*BenchmarkResult
+	Language  string
+	Timestamp time.Time
+	Metadata  map[string]string
+}
+
+// Parser defines the interface for benchmark parsers
+type Parser interface {
+	// Parse parses benchmark output and returns results
+	Parse(output []byte) (*BenchmarkSuite, error)
+
+	// Language returns the language this parser supports
+	Language() string
+}
+
+// ParseError represents a parsing error with context
+type ParseError struct {
+	Line    int
+	Message string
+	Input   string
+}
+
+func (e *ParseError) Error() string {
+	if e.Line > 0 {
+		return e.Message + " at line " + string(rune(e.Line))
+	}
+	return e.Message
+}

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -1,0 +1,42 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseError_Error(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          *ParseError
+		wantContains string
+	}{
+		{
+			name: "error with line number",
+			err: &ParseError{
+				Line:    42,
+				Message: "invalid format",
+				Input:   "test input",
+			},
+			wantContains: "at line",
+		},
+		{
+			name: "error without line number",
+			err: &ParseError{
+				Line:    0,
+				Message: "no benchmarks found",
+				Input:   "",
+			},
+			wantContains: "no benchmarks found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.err.Error()
+			if !strings.Contains(got, tt.wantContains) {
+				t.Errorf("Error() = %v, want to contain %v", got, tt.wantContains)
+			}
+		})
+	}
+}

--- a/testdata/rust/cargo_bench_bencher.txt
+++ b/testdata/rust/cargo_bench_bencher.txt
@@ -1,0 +1,8 @@
+running 5 tests
+test bench_bubble_sort ... bench:   1,234 ns/iter (+/- 56)
+test bench_quick_sort  ... bench:     567 ns/iter (+/- 23)
+test bench_merge_sort  ... bench:     890 ns/iter (+/- 45)
+test bench_heap_sort   ... bench:   1,100 ns/iter (+/- 78)
+test bench_insertion   ... bench:   2,345 ns/iter (+/- 123)
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

--- a/testdata/rust/cargo_bench_edge_cases.txt
+++ b/testdata/rust/cargo_bench_edge_cases.txt
@@ -1,0 +1,10 @@
+running 7 tests
+test bench_very_fast       ... bench:       0 ns/iter (+/- 0)
+test bench_microseconds    ... bench:   5,678,901 ns/iter (+/- 123,456)
+test bench_single_digit    ... bench:       5 ns/iter (+/- 1)
+test bench_large_variance  ... bench:   1,000 ns/iter (+/- 999)
+test bench_no_variance     ... bench:     100 ns/iter (+/- 0)
+test bench_with_underscores ... bench:  12,345,678 ns/iter (+/- 987,654)
+test result: FAILED. 6 passed; 1 failed; 0 ignored
+
+test bench_failed ... FAILED

--- a/testdata/rust/cargo_bench_with_warnings.txt
+++ b/testdata/rust/cargo_bench_with_warnings.txt
@@ -1,0 +1,18 @@
+   Compiling benchmark v0.1.0 (/path/to/project)
+warning: unused variable: `x`
+ --> src/lib.rs:10:9
+  |
+10 |     let x = 5;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+  |
+  = note: `#[warn(unused_variables)]` on by default
+
+    Finished bench [optimized] target(s) in 2.34s
+     Running unittests src/lib.rs (target/release/deps/benchmark-1234567890abcdef)
+
+running 3 tests
+test bench_fast_operation  ... bench:      42 ns/iter (+/- 3)
+test bench_slow_operation  ... bench:  10,500 ns/iter (+/- 234)
+test bench_medium_op       ... bench:   1,234 ns/iter (+/- 89)
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out


### PR DESCRIPTION
## Summary

Implements **Phase 2: Rust Benchmark Parser** with support for cargo bench bencher format output.

Closes #2

## Changes

### Parser Interface & Architecture
- ✅ Defined `Parser` interface for multi-language support
- ✅ Created `BenchmarkResult` and `BenchmarkSuite` data structures
- ✅ Implemented `ParseError` with line numbers and context
- ✅ Designed for extensibility (Python, Go, Node.js planned)

### Rust Parser Implementation
- ✅ Parses cargo bench bencher format: `test name ... bench: X ns/iter (+/- Y)`
- ✅ Extracts benchmark name, time (ns), and standard deviation
- ✅ Handles comma-separated numbers (1,234 → 1234)
- ✅ Skips failed and ignored tests gracefully
- ✅ Tolerates compiler warnings and other output

### Testing & Quality
- ✅ **82.9% test coverage** (exceeds 80% target)
- ✅ 7 comprehensive test suites with table-driven tests
- ✅ Edge cases: zero ns, large numbers, underscores in names
- ✅ File-based tests with realistic cargo bench output
- ✅ Tests for failed/ignored test handling

### Documentation
- ✅ Comprehensive package documentation (doc.go)
- ✅ Usage examples and interface patterns
- ✅ Error handling guide
- ✅ Rust parser specifics and edge cases documented

### Test Data
- `testdata/rust/cargo_bench_bencher.txt` - basic output
- `testdata/rust/cargo_bench_with_warnings.txt` - with compiler warnings
- `testdata/rust/cargo_bench_edge_cases.txt` - edge cases and failures

## Success Criteria Met

✅ Parses cargo bench output correctly  
✅ Extracts all relevant metrics (name, time, std dev)  
✅ Handles edge cases (errors, warnings, large numbers)  
✅ 82.9% test coverage (exceeds 80% target)  
✅ Comprehensive documentation  

## Implementation Highlights

```go
// Parser interface for multi-language support
type Parser interface {
    Parse(output []byte) (*BenchmarkSuite, error)
    Language() string
}

// Rust parser usage
parser := parser.NewRustParser()
suite, err := parser.Parse(cargoBenchOutput)
for _, result := range suite.Results {
    fmt.Printf("%s: %v ± %v\n", result.Name, result.Time, result.StdDev)
}
```

## Testing

```bash
# Run tests
go test ./internal/parser -v

# Check coverage
go test -cover ./internal/parser
# ok  	github.com/jpequegn/benchflow/internal/parser	0.285s	coverage: 82.9% of statements

# All project tests
go test ./...
```

## Next Steps

Ready for **Phase 3: Parallel Benchmark Execution Engine** (#3) to execute benchmarks using goroutines and channels.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)