### PR TITLE
fix: Add missing main.go and fix linter errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ vendor/
 # Build output
 bin/
 dist/
-benchflow
+/benchflow
 
 # IDE and editor files
 .vscode/

--- a/cmd/benchflow/main.go
+++ b/cmd/benchflow/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"os"
+
+	"github.com/jpequegn/benchflow/internal/cmd"
+)
+
+func main() {
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/internal/cmd/compare.go
+++ b/internal/cmd/compare.go
@@ -32,6 +32,6 @@ func init() {
 	compareCmd.Flags().StringP("current", "c", "", "current benchmark results (required)")
 	compareCmd.Flags().Float64P("threshold", "t", 1.05, "regression threshold (1.05 = 5% slower)")
 
-	compareCmd.MarkFlagRequired("baseline")
-	compareCmd.MarkFlagRequired("current")
+	_ = compareCmd.MarkFlagRequired("baseline")
+	_ = compareCmd.MarkFlagRequired("current")
 }

--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -32,5 +32,5 @@ func init() {
 	reportCmd.Flags().StringP("output", "o", "", "output file path (required)")
 	reportCmd.Flags().StringP("input", "i", "", "input benchmark results file")
 
-	reportCmd.MarkFlagRequired("output")
+	_ = reportCmd.MarkFlagRequired("output")
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -46,7 +46,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 
 	// Bind flags to viper
-	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
+	_ = viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
- Add cmd/benchflow/main.go (was missing from Phase 1)
- Fix errcheck linter errors by handling error returns
- Fix .gitignore to not ignore cmd/benchflow directory
- All tests passing, build working

Fixes:
- compareCmd.MarkFlagRequired error handling
- reportCmd.MarkFlagRequired error handling
- viper.BindPFlag error handling
- Build failure: cmd/benchflow directory not found